### PR TITLE
fix: post-payment UI shows upgrade banner instead of Pro view

### DIFF
--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -54,20 +54,31 @@ export async function POST(request: Request) {
       const customerId = subscription.customer as string
 
       const isActive = subscription.status === 'active' || subscription.status === 'trialing'
-      const status = isActive ? 'active' : 'past_due'
-      const tier = isActive ? 'pro' : 'free'
 
-      const { error } = await supabase
-        .from('profiles')
-        .update({
-          subscription_status: status,
-          subscription_tier: tier,
-        })
-        .eq('stripe_customer_id', customerId)
+      if (isActive) {
+        const { error } = await supabase
+          .from('profiles')
+          .update({
+            subscription_status: 'active',
+            subscription_tier: 'pro',
+          })
+          .eq('stripe_customer_id', customerId)
 
-      if (error) {
-        return new Response('DB update failed', { status: 500 })
+        if (error) {
+          return new Response('DB update failed', { status: 500 })
+        }
+      } else if (subscription.status === 'past_due') {
+        const { error } = await supabase
+          .from('profiles')
+          .update({ subscription_status: 'past_due' })
+          .eq('stripe_customer_id', customerId)
+
+        if (error) {
+          return new Response('DB update failed', { status: 500 })
+        }
       }
+      // Ignore other statuses (incomplete, incomplete_expired) to avoid
+      // overwriting 'active' set by checkout.session.completed
       break
     }
 

--- a/features/billing/components/upgrade-success-banner.tsx
+++ b/features/billing/components/upgrade-success-banner.tsx
@@ -1,24 +1,28 @@
 'use client'
 
 import type { JSX } from 'react'
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { checkIsPro } from '../actions'
 
-const MAX_ATTEMPTS = 15 // 15 × 2s = 30 seconds
+const MAX_ATTEMPTS = 30 // 30 × 2s = 60 seconds
 
 export function UpgradeSuccessBanner(): JSX.Element {
   const router = useRouter()
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const [timedOut, setTimedOut] = useState(false)
 
-  useEffect(() => {
+  const startPolling = useCallback(() => {
+    setTimedOut(false)
     let attempts = 0
+
+    if (intervalRef.current) clearInterval(intervalRef.current)
 
     intervalRef.current = setInterval(async () => {
       attempts++
       if (attempts >= MAX_ATTEMPTS) {
         if (intervalRef.current) clearInterval(intervalRef.current)
-        router.replace('/dashboard')
+        setTimedOut(true)
         return
       }
       try {
@@ -32,11 +36,38 @@ export function UpgradeSuccessBanner(): JSX.Element {
         // Network error — let the next interval attempt retry
       }
     }, 2000)
+  }, [router])
 
+  useEffect(() => {
+    startPolling()
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current)
     }
-  }, [router])
+  }, [startPolling])
+
+  if (timedOut) {
+    return (
+      <div className="rounded-lg border border-accent/40 bg-surface p-6 text-center">
+        <h2 className="font-heading text-xl font-extrabold">
+          Taking longer than expected
+        </h2>
+        <p className="mt-1 text-sm text-muted">
+          Your payment was received but activation is still processing.
+          Try refreshing — if the issue persists, contact support.
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            router.refresh()
+            startPolling()
+          }}
+          className="mt-4 rounded-lg bg-accent px-6 py-2 text-sm font-medium text-[#060b06] transition-opacity hover:opacity-90"
+        >
+          Retry
+        </button>
+      </div>
+    )
+  }
 
   return (
     <div className="rounded-lg border border-accent/40 bg-surface p-6 text-center">


### PR DESCRIPTION
## Summary

- `UpgradeSuccessBanner` now shows a **Retry button** con mensaje claro cuando la activación del webhook tarda más de 60s, en vez de redirigir silenciosamente al usuario de vuelta al paywall
- Ventana de polling extendida de 30s → 60s para acomodar webhooks lentos
- El webhook handler ignora los estados `incomplete`/`incomplete_expired` de suscripción para prevenir la race condition donde `customer.subscription.updated` sobrescribe el estado `active/pro` ya puesto por `checkout.session.completed`

## Root cause

Tras un checkout exitoso de Stripe, el usuario era redirigido a `/dashboard?upgraded=true` donde `UpgradeSuccessBanner` hacía polling de `checkIsPro()` cada 2s por máximo 30s. Si el webhook tardaba más, el componente llamaba `router.replace('/dashboard')` **sin** `router.refresh()`, renderizando el componente servidor con datos obsoletos — mostrando `UpgradeBanner` (el paywall) como si el usuario nunca hubiera pagado.

## Test plan

- [ ] Completar un checkout de prueba en Stripe y confirmar que aparece el banner de éxito
- [ ] Confirmar que el banner desaparece y `StartPracticeCta` renderiza al recibir el webhook
- [ ] Simular webhook lento (> 60s) y confirmar que aparece el botón Retry en vez del paywall
- [ ] Confirmar que Retry reinicia el polling y resuelve correctamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)