### PR TITLE
fix(landing): update quiz duration from 15 to 10 minutes

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -23,7 +23,7 @@ export default function LandingPage(): React.JSX.Element {
             Test Your Knowledge — Free, No Signup
           </Link>
           <span className="text-xs text-muted">
-            10 questions &middot; 15 minutes &middot; see where you stand
+            10 questions &middot; 10 minutes &middot; see where you stand
           </span>
         </div>
       </section>
@@ -122,7 +122,7 @@ export default function LandingPage(): React.JSX.Element {
             Stop guessing. Start passing.
           </h2>
           <p className="mt-4 text-sm text-muted">
-            Find out where you stand in 15 minutes — then let us build your study plan.
+            Find out where you stand in 10 minutes — then let us build your study plan.
           </p>
           <Link
             href="/diagnostic"


### PR DESCRIPTION
## Summary
- Updated landing page copy to show "10 minutes" instead of "15 minutes" in two places
- Aligns with the timer change made in e5745da

## Test plan
- [ ] Verify landing page hero shows "10 questions · 10 minutes · see where you stand"
- [ ] Verify CTA section shows "Find out where you stand in 10 minutes"

🤖 Generated with [Claude Code](https://claude.com/claude-code)