### PR TITLE
chore(billing): change launch price from €29 to €14.99

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -370,7 +370,7 @@ Show at a glance:
 
 - **No free tier. No trial without payment.**
 - The diagnostic test is the free value — it replaces both a free tier and a free trial.
-- **Pro (€29/month):** Full access — unlimited questions, all modes, full exam simulation.
+- **Pro (€14.99/month):** Full access — unlimited questions, all modes, full exam simulation.
 - Payment is required immediately after the diagnostic to unlock the app.
 - **7-day money-back guarantee** — if the user requests a refund within 7 days, process it via Stripe without questions. This is a trust signal, not a trial.
 - Stripe Checkout via Server Action — triggered from the diagnostic results page CTA
@@ -584,7 +584,7 @@ The MVP is complete when:
 - [ ] A user can take a 10-question quiz and see explanations
 - [ ] Wrong answers are tracked and surfaced in "Review Mistakes" mode
 - [ ] The dashboard shows a readiness score and domain breakdown
-- [ ] A user can pay €29/month via Stripe to unlock full access
+- [ ] A user can pay €14.99/month via Stripe to unlock full access
 - [ ] The app is live on passthecert.com via Vercel
 - [ ] At least 5 real users have paid
 

--- a/docs/stories/billing-and-subscription.md
+++ b/docs/stories/billing-and-subscription.md
@@ -3,7 +3,7 @@
 ## Épica
 
 **Como** visitante o usuario registrado,
-**quiero** poder suscribirme al plan Pro (€29/mes) ya sea después del diagnóstico o directamente desde pricing, y gestionar mi información de facturación cuando lo necesite,
+**quiero** poder suscribirme al plan Pro (€14,99/mes) ya sea después del diagnóstico o directamente desde pricing, y gestionar mi información de facturación cuando lo necesite,
 **para que** pueda acceder al contenido de preparación sin fricciones y mantener mis datos de pago actualizados.
 
 ---
@@ -18,7 +18,7 @@
 
 1. **Given** el visitante está en la página de resultados del diagnóstico,
    **when** hace click en "Empieza tu plan de estudio personalizado",
-   **then** se le redirige a Google OAuth si no tiene cuenta, y después a Stripe Checkout con el plan Pro (€29/mes).
+   **then** se le redirige a Google OAuth si no tiene cuenta, y después a Stripe Checkout con el plan Pro (€14,99/mes).
 
 2. **Given** el visitante ya tiene una sesión activa (hizo login antes),
    **when** hace click en el CTA,
@@ -46,7 +46,7 @@
 ### Criterios de aceptación
 
 1. **Given** el visitante está en la página de pricing (`/pricing`),
-   **when** hace click en "Suscríbete — €29/mes",
+   **when** hace click en "Suscríbete — €14,99/mes",
    **then** se le redirige a Google OAuth y después a Stripe Checkout.
 
 2. **Given** el visitante llega a la landing page,
@@ -76,7 +76,7 @@
    **then** se le redirige a una página de checkout/paywall.
 
 2. **Given** la página de paywall,
-   **then** muestra el precio (€29/mes), la garantía de 7 días, y un único botón hacia Stripe Checkout.
+   **then** muestra el precio (€14,99/mes), la garantía de 7 días, y un único botón hacia Stripe Checkout.
 
 3. **Given** el usuario completa el pago desde el paywall,
    **when** el webhook confirma,


### PR DESCRIPTION
## Summary
- Update Pro plan launch price from **€29/mo** to **€14.99/mo** across the single source of truth (`features/billing/constants.ts`) — this automatically updates paywall, upgrade banner, diagnostic results CTA, and the pricing page CTA that consume `PRICE_AMOUNT`/`PRICE_LABEL`/`PRICE_CTA`
- Fix hardcoded price strings on the landing (`app/(marketing)/page.tsx`) and pricing page (`app/(marketing)/pricing/page.tsx`)
- Align `INSTRUCTIONS.md` MVP spec and `docs/stories/billing-and-subscription.md` HU-1/HU-2/HU-3 with the new launch price

## Follow-up required (not in this PR)
- [ ] Create a new **€14.99/mo Price** in Stripe Dashboard (Prices are immutable — must create new, archive old €29 one)
- [ ] Update `STRIPE_PRO_PRICE_ID` env var in Vercel production + local `.env.local`
- [ ] Redeploy on Vercel to pick up the new env var

## Test plan
- [x] `/` landing renders **€14.99/mo** in the Pro card (verified in preview)
- [x] `/pricing` renders **€14.99/mo** in the hero + **Subscribe — €14.99/mo** CTA (verified in preview)
- [ ] Smoke test post-merge after Stripe Price swap: complete a Stripe Checkout and confirm €14.99 charge + webhook → `subscription_status = active`

🤖 Generated with [Claude Code](https://claude.com/claude-code)