### PR TITLE
fix(billing): update displayed price from €29 to €14.99

### DIFF
--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,3 +1,4 @@
+import { PRICE_AMOUNT } from '@/features/billing'
 import Link from 'next/link'
 
 export default function LandingPage(): React.JSX.Element {
@@ -82,7 +83,7 @@ export default function LandingPage(): React.JSX.Element {
                 Pro
               </h3>
               <p className="font-heading text-4xl font-extrabold">
-                €14.99<span className="text-lg text-muted">/mo</span>
+                {PRICE_AMOUNT}<span className="text-lg text-muted">/mo</span>
               </p>
             </div>
             <ul className="mt-6 space-y-3 text-sm">

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -82,7 +82,7 @@ export default function LandingPage(): React.JSX.Element {
                 Pro
               </h3>
               <p className="font-heading text-4xl font-extrabold">
-                €29<span className="text-lg text-muted">/mo</span>
+                €14.99<span className="text-lg text-muted">/mo</span>
               </p>
             </div>
             <ul className="mt-6 space-y-3 text-sm">

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -1,5 +1,5 @@
 import { getUser } from '@/features/auth'
-import { checkIsPro, createCheckoutAndRedirect, PRICE_CTA } from '@/features/billing'
+import { checkIsPro, createCheckoutAndRedirect, PRICE_AMOUNT, PRICE_CTA } from '@/features/billing'
 import Link from 'next/link'
 
 const FEATURES = [
@@ -30,7 +30,7 @@ export default async function PricingPage(): Promise<React.JSX.Element> {
             Pro
           </h2>
           <p className="font-heading text-4xl font-extrabold">
-            &euro;14.99<span className="text-lg text-muted">/mo</span>
+            {PRICE_AMOUNT}<span className="text-lg text-muted">/mo</span>
           </p>
         </div>
 

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -30,7 +30,7 @@ export default async function PricingPage(): Promise<React.JSX.Element> {
             Pro
           </h2>
           <p className="font-heading text-4xl font-extrabold">
-            &euro;29<span className="text-lg text-muted">/mo</span>
+            &euro;14.99<span className="text-lg text-muted">/mo</span>
           </p>
         </div>
 

--- a/features/billing/constants.ts
+++ b/features/billing/constants.ts
@@ -1,4 +1,4 @@
-export const PRICE_AMOUNT = '€29'
+export const PRICE_AMOUNT = '€14.99'
 export const PRICE_INTERVAL = 'mo'
 export const PRICE_LABEL = `${PRICE_AMOUNT}/${PRICE_INTERVAL}`
 export const PRICE_CTA = `Subscribe — ${PRICE_LABEL}`


### PR DESCRIPTION
## Summary
- Update hardcoded price display from €29 to €14.99 across all pages
- Fix `features/billing/constants.ts` (`PRICE_AMOUNT`) — affects CTA buttons in upgrade banner, paywall, and diagnostic results
- Fix `app/(marketing)/pricing/page.tsx` — dedicated pricing page
- Fix `app/(marketing)/page.tsx` — landing page pricing section

## Test plan
- [ ] Visit `/pricing` — should show €14.99/mo and "Subscribe — €14.99/mo" button
- [ ] Visit `/` (landing) — pricing section should show €14.99/mo
- [ ] Visit `/dashboard` as free user — upgrade banner should show €14.99/mo
- [ ] Stripe checkout flow initiates correctly with the new price ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)