### PR TITLE
fix: quiz final score display and diagnostic lead conversion tracking

### DIFF
--- a/app/(auth)/auth/callback/route.ts
+++ b/app/(auth)/auth/callback/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from 'next/server'
-import { createClient } from '@/shared/lib/supabase'
+import { createClient, createAdminClient } from '@/shared/lib/supabase'
 
 export async function GET(request: Request): Promise<NextResponse> {
   const { searchParams, origin } = new URL(request.url)
@@ -10,9 +10,19 @@ export async function GET(request: Request): Promise<NextResponse> {
 
   if (code) {
     const supabase = await createClient()
-    const { error } = await supabase.auth.exchangeCodeForSession(code)
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
 
     if (!error) {
+      const email = data.user?.email
+      if (email) {
+        const admin = createAdminClient()
+        await admin
+          .from('diagnostic_leads')
+          .update({ converted_at: new Date().toISOString() })
+          .eq('email', email)
+          .is('converted_at', null)
+      }
+
       const destination = type === 'recovery' ? '/auth/reset-password' : next
       return NextResponse.redirect(new URL(destination, origin))
     }

--- a/features/quiz/components/quiz-client.tsx
+++ b/features/quiz/components/quiz-client.tsx
@@ -23,6 +23,7 @@ export function QuizClient({
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [result, setResult] = useState<AnswerResult | null>(null)
   const [questionIndex, setQuestionIndex] = useState(1)
+  const [correctCount, setCorrectCount] = useState(0)
   const [isSubmitting, startSubmit] = useTransition()
   const [isLoadingNext, startLoadNext] = useTransition()
   const [sessionComplete, setSessionComplete] = useState(false)
@@ -48,6 +49,9 @@ export function QuizClient({
         selectedKey
       )
       setResult(answerResult)
+      if (answerResult.isCorrect) {
+        setCorrectCount((c) => c + 1)
+      }
     })
   }
 
@@ -57,12 +61,7 @@ export function QuizClient({
       if (!nextQuestion) {
         setSessionComplete(true)
         setFinalScore({
-          correct: result
-            ? (result.isCorrect
-                ? questionIndex
-                : questionIndex - 1) +
-              (result.isCorrect ? 0 : 0)
-            : 0,
+          correct: correctCount,
           total: totalQuestions,
         })
         return
@@ -84,9 +83,9 @@ export function QuizClient({
           <p className="text-lg text-muted">
             You got{' '}
             <span className="text-accent font-medium">
-              {result?.questionIndex ?? 0}
+              {finalScore.correct}
             </span>{' '}
-            out of {totalQuestions} questions
+            out of {finalScore.total} questions
           </p>
         )}
         <div className="flex gap-4">


### PR DESCRIPTION
## Summary
- **Quiz score bug**: `correctCount` state now tracks correct answers across the session; final screen shows the real score instead of `questionIndex` (question position)
- **Conversion tracking**: Auth callback sets `converted_at` on `diagnostic_leads` when a lead authenticates via OAuth, enabling diagnostic→paid funnel analytics

## Test plan
- [ ] Complete a Quick 10 quiz — verify "You got X out of 10" shows the actual correct answer count
- [ ] Take the diagnostic as anonymous user, submit email, then sign in with Google — verify `diagnostic_leads.converted_at` is populated in Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)