### PR TITLE
fix(progress): student-centered domain mastery metrics

### DIFF
--- a/features/progress/actions.ts
+++ b/features/progress/actions.ts
@@ -48,7 +48,7 @@ export async function updateReadinessScore(userId: string, examId: string) {
         last_activity_at: new Date().toISOString(),
         updated_at: new Date().toISOString(),
       },
-      { onConflict: 'user_id' }
+      { onConflict: 'user_id,exam_id' }
     )
 
   return overallScore

--- a/features/progress/components/dashboard-greeting.tsx
+++ b/features/progress/components/dashboard-greeting.tsx
@@ -18,9 +18,9 @@ function getGreeting(hour: number): string {
 }
 
 function getReadinessLabel(score: number): string {
-  if (score >= 70) return 'Ready to Pass'
-  if (score >= 40) return 'Getting There'
-  return 'Not Ready'
+  if (score >= 75) return 'Ready to Pass'
+  if (score >= 50) return 'Getting There'
+  return 'Keep Practicing'
 }
 
 export function DashboardGreeting({

--- a/features/progress/components/domain-mastery.tsx
+++ b/features/progress/components/domain-mastery.tsx
@@ -6,7 +6,9 @@ interface DomainData {
   code: string
   weightPct: number
   correctPct: number
+  coveredPct: number
   totalAnswered: number
+  totalInDomain: number
 }
 
 interface DomainMasteryProps {
@@ -18,8 +20,10 @@ export function DomainMastery({ domains, examSlug }: DomainMasteryProps) {
   return (
     <div id="domains" className="rounded-lg border border-border bg-surface p-6">
       <h3 className="font-heading text-lg font-extrabold">Domain Mastery</h3>
-      <p className="mt-1 text-xs text-muted">Click a domain to practice</p>
-      <div className="mt-4 space-y-2">
+      <p className="mt-1 text-xs text-muted">
+        Accuracy on questions you&apos;ve practiced · Click to focus on a domain
+      </p>
+      <div className="mt-4 space-y-3">
         {domains.map((domain) => (
           <Link
             key={domain.domainId}
@@ -31,20 +35,27 @@ export function DomainMastery({ domains, examSlug }: DomainMasteryProps) {
                 {domain.code} {domain.domainName}
               </span>
               <div className="flex items-center gap-2">
-                <span className="text-muted">
+                <span className="font-medium text-foreground">
                   {domain.correctPct}%
-                  <span className="ml-1 text-xs">
-                    ({domain.totalAnswered} answered)
-                  </span>
                 </span>
                 <span className="text-muted">&#8250;</span>
               </div>
             </div>
+            {/* Accuracy bar */}
             <div className="h-2 rounded-full bg-background">
               <div
                 className="h-full rounded-full bg-accent transition-all duration-500"
                 style={{ width: `${domain.correctPct}%` }}
               />
+            </div>
+            {/* Coverage info */}
+            <div className="mt-1.5 flex items-center justify-between">
+              <span className="text-xs text-muted">
+                {domain.totalAnswered} / {domain.totalInDomain} questions seen
+              </span>
+              <span className="text-xs text-muted">
+                {domain.coveredPct}% covered · {domain.weightPct}% of exam
+              </span>
             </div>
           </Link>
         ))}

--- a/features/progress/components/readiness-card.tsx
+++ b/features/progress/components/readiness-card.tsx
@@ -3,9 +3,9 @@ interface ReadinessCardProps {
 }
 
 function getLabel(score: number) {
-  if (score >= 70) return 'Ready to Pass'
-  if (score >= 40) return 'Getting There'
-  return 'Not Ready'
+  if (score >= 75) return 'Ready to Pass'
+  if (score >= 50) return 'Getting There'
+  return 'Keep Practicing'
 }
 
 export function ReadinessCard({ score }: ReadinessCardProps) {

--- a/features/progress/queries.ts
+++ b/features/progress/queries.ts
@@ -24,24 +24,51 @@ export async function getDomainMastery(userId: string, examId: string) {
 
   if (!domains) return []
 
+  // Get total question count per domain
+  const { data: allQuestions } = await supabase
+    .from('questions')
+    .select('domain_id')
+    .in(
+      'domain_id',
+      domains.map((d) => d.id)
+    )
+
+  const totalByDomain = new Map<string, number>()
+  for (const q of allQuestions ?? []) {
+    totalByDomain.set(q.domain_id, (totalByDomain.get(q.domain_id) ?? 0) + 1)
+  }
+
   const results = await Promise.all(
     domains.map(async (domain) => {
+      // Fetch all responses for this domain, ordered newest first
       const { data: responses } = await supabase
         .from('user_responses')
-        .select('is_correct, questions!inner(domain_id)')
+        .select('question_id, is_correct, created_at, questions!inner(domain_id)')
         .eq('user_id', userId)
         .eq('questions.domain_id', domain.id)
+        .order('created_at', { ascending: false })
 
-      const total = responses?.length ?? 0
-      const correct = responses?.filter((r) => r.is_correct).length ?? 0
+      // Keep only the latest answer per question
+      const latestByQuestion = new Map<string, boolean>()
+      for (const r of responses ?? []) {
+        if (!latestByQuestion.has(r.question_id)) {
+          latestByQuestion.set(r.question_id, r.is_correct)
+        }
+      }
+
+      const uniqueSeen = latestByQuestion.size
+      const correctLatest = [...latestByQuestion.values()].filter(Boolean).length
+      const totalInDomain = totalByDomain.get(domain.id) ?? 0
 
       return {
         domainId: domain.id,
         domainName: domain.name,
         code: domain.code,
         weightPct: domain.weight_pct,
-        correctPct: total > 0 ? Math.round((correct / total) * 100) : 0,
-        totalAnswered: total,
+        correctPct: uniqueSeen > 0 ? Math.round((correctLatest / uniqueSeen) * 100) : 0,
+        coveredPct: totalInDomain > 0 ? Math.round((uniqueSeen / totalInDomain) * 100) : 0,
+        totalAnswered: uniqueSeen,
+        totalInDomain,
       }
     })
   )

--- a/supabase/migrations/015_fix_readiness_scores_constraint.sql
+++ b/supabase/migrations/015_fix_readiness_scores_constraint.sql
@@ -1,0 +1,15 @@
+-- Fix readiness_scores to support multiple exams per user.
+-- The original schema had a unique constraint on user_id alone, which prevents
+-- a user from having a separate readiness score per exam.
+
+-- Drop single-column unique constraint
+alter table public.readiness_scores
+  drop constraint readiness_scores_user_id_key;
+
+-- Add composite unique constraint so upsert can target (user_id, exam_id)
+alter table public.readiness_scores
+  add constraint readiness_scores_user_id_exam_id_key unique (user_id, exam_id);
+
+-- Add missing INSERT policy (upserts for new users were blocked by RLS)
+create policy "Users can insert own readiness" on public.readiness_scores
+  for insert with check (auth.uid() = user_id);


### PR DESCRIPTION
## Summary
- **Fix domain % calculation**: now uses latest answer per question (not all-time history), so early mistakes no longer permanently drag down the score
- **Add coverage metrics**: each domain now shows `X / Y questions seen` and `% covered` so students know how much of the domain they've actually practiced
- **Raise readiness thresholds**: "Ready to Pass" moved to 75% (matches real CompTIA passing score); mid-tier raised to 50%; "Not Ready" renamed to "Keep Practicing"
- **Bug fix**: `upsert` conflict target corrected from `user_id` to `user_id,exam_id` to support multiple exams per user

## Test plan
- [ ] Dashboard shows updated domain percentages reflecting only the latest attempt per question
- [ ] Each domain row displays both accuracy (%) and coverage (X / Y questions seen · Z% covered)
- [ ] Readiness score label shows "Ready to Pass" at ≥75%, "Getting There" at ≥50%, "Keep Practicing" below 50%
- [ ] A user with two exams enrolled does not have their readiness score overwritten

🤖 Generated with [Claude Code](https://claude.com/claude-code)