### PR TITLE
fix(analytics): fix PostHog identity split and AuthSync gaps

### DIFF
--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -4,7 +4,7 @@ import posthog from 'posthog-js'
 import { PostHogProvider, usePostHog } from 'posthog-js/react'
 import { useEffect, Suspense } from 'react'
 import { usePathname, useSearchParams } from 'next/navigation'
-import type { AuthChangeEvent, Session } from '@supabase/supabase-js'
+import type { AuthChangeEvent, Session, User } from '@supabase/supabase-js'
 import { createBrowserClient } from '@/shared/lib/supabase-browser'
 
 if (typeof window !== 'undefined') {
@@ -37,11 +37,24 @@ function AuthSync(): null {
 
   useEffect(() => {
     const supabase = createBrowserClient()
+
+    // Identify users already authenticated on first load (INITIAL_SESSION does not
+    // fire a SIGNED_IN event in newer Supabase versions)
+    supabase.auth.getUser().then(({ data }: { data: { user: User | null } }) => {
+      if (data.user) {
+        ph.identify(data.user.id, { email: data.user.email })
+        if (data.user.email) ph.alias(data.user.email)
+      }
+    })
+
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event: AuthChangeEvent, session: Session | null) => {
       if (event === 'SIGNED_IN' && session?.user) {
         ph.identify(session.user.id, { email: session.user.email })
+        // Link the email distinctId (used by the anonymous diagnostic funnel)
+        // to the Supabase userId so PostHog can connect pre-signup events
+        if (session.user.email) ph.alias(session.user.email)
       } else if (event === 'SIGNED_OUT') {
         ph.reset()
       }

--- a/shared/lib/supabase-browser.ts
+++ b/shared/lib/supabase-browser.ts
@@ -1,8 +1,10 @@
 import { createBrowserClient as createBrowser } from '@supabase/ssr'
 
 export function createBrowserClient(): ReturnType<typeof createBrowser> {
-  return createBrowser(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY!
-  )
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const key = process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY
+  if (!url || !key) {
+    throw new Error('Missing Supabase environment variables: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY are required')
+  }
+  return createBrowser(url, key)
 }


### PR DESCRIPTION
## Summary

- **Medium — Funnel identity split**: `AuthSync` now calls `ph.alias(email)` immediately after `ph.identify(userId)` on every `SIGNED_IN` event. This tells PostHog that the email-based `distinctId` (fired during the anonymous diagnostic funnel) and the Supabase `userId` belong to the same person, repairing the `email_captured → checkout_started` chain.
- **Minor — AuthSync misses already-authenticated users**: Added a `supabase.auth.getUser()` call on mount alongside the `onAuthStateChange` listener. Users who are already logged in when the app first loads are now identified immediately, without waiting for their next sign-in.
- **Minor — non-null assertions in `supabase-browser.ts`**: Replaced `!` assertions with explicit env var validation that throws a descriptive error on misconfiguration, consistent with the rest of the server-side client pattern.

## Test plan

- [ ] Log in as a fresh user — PostHog person profile should show `userId` as distinct ID with `email` as alias
- [ ] Reload app while already authenticated — PostHog should capture `$identify` on page load without a new sign-in
- [ ] Remove `NEXT_PUBLIC_SUPABASE_URL` from `.env.local` and confirm the browser client throws a readable error instead of silently passing `undefined`

🤖 Generated with [Claude Code](https://claude.com/claude-code)