### PR TITLE
refactor(diagnostic): strip locked results page to MVP email gate

### DIFF
--- a/features/diagnostic/components/diagnostic-client.tsx
+++ b/features/diagnostic/components/diagnostic-client.tsx
@@ -384,14 +384,13 @@ export function DiagnosticClient({
   }
 
   // --- Results (locked) ---
+  // MVP: only the email gate + retake. All score/probability/domain UI lives
+  // in the unlocked state, where the user has earned it.
   if (phase === 'results' && result) {
     return (
       <div className="mx-auto max-w-2xl space-y-8 py-10">
-        <DiagnosticResults result={result} isUnlocked={false} isLoggedIn={isLoggedIn} />
         <EmailGate result={result} onUnlock={handleUnlock} />
-        {/* Demoted retake link: tiny, muted, below the fold — present but not
-            competing with the email CTA. */}
-        <div className="pt-6 text-center">
+        <div className="pt-2 text-center">
           <button
             onClick={handleRestart}
             className="text-xs text-muted/60 underline-offset-2 transition-colors hover:text-muted hover:underline"

--- a/features/diagnostic/components/diagnostic-client.tsx
+++ b/features/diagnostic/components/diagnostic-client.tsx
@@ -389,12 +389,14 @@ export function DiagnosticClient({
       <div className="mx-auto max-w-2xl space-y-8 py-10">
         <DiagnosticResults result={result} isUnlocked={false} isLoggedIn={isLoggedIn} />
         <EmailGate result={result} onUnlock={handleUnlock} />
-        <div className="text-center">
+        {/* Demoted retake link: tiny, muted, below the fold — present but not
+            competing with the email CTA. */}
+        <div className="pt-6 text-center">
           <button
             onClick={handleRestart}
-            className="text-sm text-muted underline transition-colors hover:text-foreground"
+            className="text-xs text-muted/60 underline-offset-2 transition-colors hover:text-muted hover:underline"
           >
-            Retake Diagnostic
+            Retake diagnostic
           </button>
         </div>
       </div>

--- a/features/diagnostic/components/diagnostic-client.tsx
+++ b/features/diagnostic/components/diagnostic-client.tsx
@@ -406,13 +406,13 @@ export function DiagnosticClient({
   if (phase === 'unlocked' && result) {
     return (
       <div className="mx-auto max-w-2xl space-y-8 py-10">
-        <DiagnosticResults result={result} isUnlocked={true} isLoggedIn={isLoggedIn} />
-        <div className="text-center">
+        <DiagnosticResults result={result} isLoggedIn={isLoggedIn} />
+        <div className="pt-2 text-center">
           <button
             onClick={handleRestart}
-            className="text-sm text-muted underline transition-colors hover:text-foreground"
+            className="text-xs text-muted/60 underline-offset-2 transition-colors hover:text-muted hover:underline"
           >
-            Retake Diagnostic
+            Retake diagnostic
           </button>
         </div>
       </div>

--- a/features/diagnostic/components/diagnostic-results.tsx
+++ b/features/diagnostic/components/diagnostic-results.tsx
@@ -54,14 +54,6 @@ function hoursToReady(score: number): number {
   return Math.round(gap * 1.2)
 }
 
-function readinessLabel(score: number): string {
-  if (score >= PASSING_ZONE) return "You're in the passing zone — keep sharpening."
-  if (score >= 55) return 'Solid foundation — targeted practice will close the gap.'
-  if (score >= 35) return 'Meaningful gaps identified — a plan fixes this fast.'
-  if (score >= 21) return "You're far from ready today — but that's exactly what this tool fixes."
-  return "Starting from scratch is a feature, not a bug — SM-2 builds memory right the first time."
-}
-
 interface PhasePlan {
   rangeLabel: string
   body: React.ReactNode
@@ -157,7 +149,7 @@ export function DiagnosticResults({
 
   return (
     <div className="space-y-8">
-      {/* Readiness Score */}
+      {/* Readiness Score hero — one anchor number, no redundant copy */}
       <div className="text-center">
         <p className="text-sm uppercase tracking-wider text-muted">
           Your Readiness Score
@@ -169,7 +161,7 @@ export function DiagnosticResults({
           <span className="text-3xl text-muted">/100</span>
         </p>
         <p className="mt-2 text-xs text-muted">
-          {result.correctCount} of {result.totalQuestions} correct · Passing zone starts at {PASSING_ZONE}
+          {result.correctCount} of {result.totalQuestions} correct
         </p>
 
         {/* Progress bar with passing zone marker.
@@ -194,51 +186,44 @@ export function DiagnosticResults({
             style={{ left: `${PASSING_ZONE}%` }}
           />
         </div>
-        <p className="mt-3 text-sm text-muted">{readinessLabel(readiness)}</p>
+        <p className="mt-2 text-xs text-muted">
+          Passing zone starts at {PASSING_ZONE}
+        </p>
       </div>
 
-      {/* Key metrics: Pass probability + Time to ready */}
-      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div className="rounded-lg border border-border bg-surface p-4 text-center">
-          <p className="text-xs uppercase tracking-wider text-muted">
-            Probability of passing today
-          </p>
-          <p
-            className={`mt-1 font-heading text-3xl font-extrabold ${scoreColor(passProb)}`}
-          >
-            {passProb}%
-          </p>
-          <p className="mt-1 text-xs text-muted">
-            Based on your current score vs. the 75-point passing zone.
-          </p>
-        </div>
-        <div className="rounded-lg border border-border bg-surface p-4 text-center">
-          {hoursNeeded === 0 ? (
-            <>
-              <p className="text-xs uppercase tracking-wider text-muted">
-                You&apos;re in the passing zone
-              </p>
-              <p className="mt-1 font-heading text-3xl font-extrabold text-accent">
-                Ready
-              </p>
-              <p className="mt-1 text-xs text-muted">
-                Maintain with daily reviews so you don&apos;t lose it before exam day.
-              </p>
-            </>
-          ) : (
-            <>
-              <p className="text-xs uppercase tracking-wider text-muted">
-                Focused practice to be ready
-              </p>
-              <p className="mt-1 font-heading text-3xl font-extrabold text-foreground">
-                ~{hoursNeeded}h
-              </p>
-              <p className="mt-1 text-xs text-muted">
-                About {weeks} {weeks === 1 ? 'week' : 'weeks'} at 1h/day with spaced repetition.
-              </p>
-            </>
-          )}
-        </div>
+      {/* Unified stat card: pass probability is the lead, hours is the context */}
+      <div className="rounded-lg border border-border bg-surface p-5 text-center">
+        {hoursNeeded === 0 ? (
+          <>
+            <p className="text-xs uppercase tracking-wider text-muted">
+              Probability of passing today
+            </p>
+            <p
+              className={`mt-1 font-heading text-4xl font-extrabold ${scoreColor(passProb)}`}
+            >
+              {passProb}%
+            </p>
+            <p className="mt-2 text-sm text-muted">
+              You&apos;re in the passing zone — daily reviews keep it that way.
+            </p>
+          </>
+        ) : (
+          <>
+            <p className="text-xs uppercase tracking-wider text-muted">
+              Probability of passing today
+            </p>
+            <p
+              className={`mt-1 font-heading text-4xl font-extrabold ${scoreColor(passProb)}`}
+            >
+              {passProb}%
+            </p>
+            <p className="mt-2 text-sm text-muted">
+              <span className="font-medium text-foreground">~{hoursNeeded}h</span>{' '}
+              of focused practice (~{weeks} {weeks === 1 ? 'week' : 'weeks'} at
+              1h/day) closes the gap to the passing zone.
+            </p>
+          </>
+        )}
       </div>
 
       {/* Weakest Domain Teaser (blurred before email) */}
@@ -257,10 +242,19 @@ export function DiagnosticResults({
           </div>
           <p className="mt-3 text-sm text-muted">
             One domain is pulling your score down more than the others.
-            Knowing which one lets you focus the first two weeks of practice
-            where it matters most.
+            Knowing which one lets you focus your first week of practice where
+            it matters most.
           </p>
         </div>
+      )}
+
+      {/* Accuracy disclaimer — only shown before unlock */}
+      {!isUnlocked && (
+        <p className="text-center text-xs text-muted/70">
+          This is a 10-question snapshot — directionally accurate, not
+          definitive. The full tool tracks hundreds of responses over time to
+          refine your readiness score as you practice.
+        </p>
       )}
 
       {/* Domain Breakdown (revealed after email) */}
@@ -305,18 +299,22 @@ export function DiagnosticResults({
         </div>
       )}
 
-      {/* Scientific social proof (honest, cited) */}
-      <div className="rounded-lg border border-accent/20 bg-accent/5 p-4">
-        <p className="text-sm text-foreground">
-          <span className="font-medium text-accent">Why this works:</span>{' '}
-          Spaced repetition is one of the most-studied learning techniques in
-          cognitive science. Meta-analyses show it can produce 2× better
-          long-term retention than massed practice.
-        </p>
-        <p className="mt-2 text-xs text-muted">
-          Cepeda et al. (2006), <em>Psychological Bulletin</em>, meta-analysis of 317 experiments.
-        </p>
-      </div>
+      {/* Scientific social proof — shown only after unlock, as a pre-CTA
+          reassurance for a user already invested. Before unlock it was just
+          cognitive noise in the email-conversion flow. */}
+      {isUnlocked && (
+        <div className="rounded-lg border border-accent/20 bg-accent/5 p-4">
+          <p className="text-sm text-foreground">
+            <span className="font-medium text-accent">Why this works:</span>{' '}
+            Spaced repetition is one of the most-studied learning techniques
+            in cognitive science. Meta-analyses show it can produce 2× better
+            long-term retention than massed practice.
+          </p>
+          <p className="mt-2 text-xs text-muted">
+            Cepeda et al. (2006), <em>Psychological Bulletin</em>, meta-analysis of 317 experiments.
+          </p>
+        </div>
+      )}
 
       {/* Plan + paid CTA (only when unlocked) */}
       {isUnlocked && (

--- a/features/diagnostic/components/diagnostic-results.tsx
+++ b/features/diagnostic/components/diagnostic-results.tsx
@@ -10,7 +10,6 @@ import { PRICE_LABEL } from '@/features/billing/constants'
 
 interface DiagnosticResultsProps {
   result: DiagnosticResult
-  isUnlocked: boolean
   isLoggedIn: boolean
 }
 
@@ -135,7 +134,6 @@ function buildPhasePlan(weeks: number, weakestDomain: string): PhasePlan[] {
 
 export function DiagnosticResults({
   result,
-  isUnlocked,
   isLoggedIn,
 }: DiagnosticResultsProps) {
   const readiness = result.overallScore
@@ -191,75 +189,33 @@ export function DiagnosticResults({
         </p>
       </div>
 
-      {/* Unified stat card: pass probability is the lead, hours is the context */}
+      {/* Unified stat card: pass probability is the lead, hours is the context.
+          The header + big percentage are constant; only the sub-copy branches
+          on whether the user is already in the passing zone. */}
       <div className="rounded-lg border border-border bg-surface p-5 text-center">
-        {hoursNeeded === 0 ? (
-          <>
-            <p className="text-xs uppercase tracking-wider text-muted">
-              Probability of passing today
-            </p>
-            <p
-              className={`mt-1 font-heading text-4xl font-extrabold ${scoreColor(passProb)}`}
-            >
-              {passProb}%
-            </p>
-            <p className="mt-2 text-sm text-muted">
-              You&apos;re in the passing zone — daily reviews keep it that way.
-            </p>
-          </>
-        ) : (
-          <>
-            <p className="text-xs uppercase tracking-wider text-muted">
-              Probability of passing today
-            </p>
-            <p
-              className={`mt-1 font-heading text-4xl font-extrabold ${scoreColor(passProb)}`}
-            >
-              {passProb}%
-            </p>
-            <p className="mt-2 text-sm text-muted">
+        <p className="text-xs uppercase tracking-wider text-muted">
+          Probability of passing today
+        </p>
+        <p
+          className={`mt-1 font-heading text-4xl font-extrabold ${scoreColor(passProb)}`}
+        >
+          {passProb}%
+        </p>
+        <p className="mt-2 text-sm text-muted">
+          {hoursNeeded === 0 ? (
+            <>You&apos;re in the passing zone — daily reviews keep it that way.</>
+          ) : (
+            <>
               <span className="font-medium text-foreground">~{hoursNeeded}h</span>{' '}
               of focused practice (~{weeks} {weeks === 1 ? 'week' : 'weeks'} at
               1h/day) closes the gap to the passing zone.
-            </p>
-          </>
-        )}
+            </>
+          )}
+        </p>
       </div>
 
-      {/* Weakest Domain Teaser (blurred before email) */}
-      {!isUnlocked && (
-        <div className="rounded-lg border border-danger/30 bg-surface p-5">
-          <p className="text-xs uppercase tracking-wider text-muted">
-            Your weakest domain
-          </p>
-          <div className="mt-2 flex items-center justify-between">
-            <p className="select-none font-heading text-lg font-extrabold text-danger blur-[6px]">
-              ████████████████████
-            </p>
-            <span className="select-none font-heading text-lg font-extrabold text-danger blur-[6px]">
-              ██%
-            </span>
-          </div>
-          <p className="mt-3 text-sm text-muted">
-            One domain is pulling your score down more than the others.
-            Knowing which one lets you focus your first week of practice where
-            it matters most.
-          </p>
-        </div>
-      )}
-
-      {/* Accuracy disclaimer — only shown before unlock */}
-      {!isUnlocked && (
-        <p className="text-center text-xs text-muted/70">
-          This is a 10-question snapshot — directionally accurate, not
-          definitive. The full tool tracks hundreds of responses over time to
-          refine your readiness score as you practice.
-        </p>
-      )}
-
-      {/* Domain Breakdown (revealed after email) */}
-      {isUnlocked && (
-        <div>
+      {/* Domain Breakdown */}
+      <div>
           <h3 className="mb-4 font-heading text-lg font-extrabold">
             Domain Breakdown
           </h3>
@@ -297,28 +253,23 @@ export function DiagnosticResults({
             ))}
           </div>
         </div>
-      )}
 
-      {/* Scientific social proof — shown only after unlock, as a pre-CTA
-          reassurance for a user already invested. Before unlock it was just
-          cognitive noise in the email-conversion flow. */}
-      {isUnlocked && (
-        <div className="rounded-lg border border-accent/20 bg-accent/5 p-4">
-          <p className="text-sm text-foreground">
-            <span className="font-medium text-accent">Why this works:</span>{' '}
-            Spaced repetition is one of the most-studied learning techniques
-            in cognitive science. Meta-analyses show it can produce 2× better
-            long-term retention than massed practice.
-          </p>
-          <p className="mt-2 text-xs text-muted">
-            Cepeda et al. (2006), <em>Psychological Bulletin</em>, meta-analysis of 317 experiments.
-          </p>
-        </div>
-      )}
+      {/* Scientific social proof — pre-CTA reassurance for a user who has
+          already submitted their email and is deciding whether to pay. */}
+      <div className="rounded-lg border border-accent/20 bg-accent/5 p-4">
+        <p className="text-sm text-foreground">
+          <span className="font-medium text-accent">Why this works:</span>{' '}
+          Spaced repetition is one of the most-studied learning techniques in
+          cognitive science. Meta-analyses show it can produce 2× better
+          long-term retention than massed practice.
+        </p>
+        <p className="mt-2 text-xs text-muted">
+          Cepeda et al. (2006), <em>Psychological Bulletin</em>, meta-analysis of 317 experiments.
+        </p>
+      </div>
 
-      {/* Plan + paid CTA (only when unlocked) */}
-      {isUnlocked && (
-        <div className="rounded-lg border border-accent/30 bg-surface p-6">
+      {/* Plan + paid CTA */}
+      <div className="rounded-lg border border-accent/30 bg-surface p-6">
           {isInPassingZone ? (
             <>
               <h3 className="font-heading text-lg font-extrabold">
@@ -448,8 +399,7 @@ export function DiagnosticResults({
               </div>
             </>
           )}
-        </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/features/diagnostic/components/email-gate.tsx
+++ b/features/diagnostic/components/email-gate.tsx
@@ -49,35 +49,14 @@ export function EmailGate({ result, onUnlock }: EmailGateProps) {
   return (
     <div className="rounded-lg border border-accent/30 bg-surface p-6">
       <h3 className="font-heading text-lg font-extrabold">
-        Where should we send your personalized study plan?
+        See your full results
       </h3>
       <p className="mt-2 text-sm text-muted">
-        Drop your email and we&apos;ll unlock + send you:
+        Your weakest domain, score breakdown and a personalized study plan —
+        sent to your inbox.
       </p>
 
-      <ul className="mt-3 space-y-2 text-sm text-foreground">
-        <li className="flex items-start gap-2">
-          <span className="mt-0.5 text-accent">✓</span>
-          <span>
-            Your weakest domain (and why it&apos;s costing you the most points)
-          </span>
-        </li>
-        <li className="flex items-start gap-2">
-          <span className="mt-0.5 text-accent">✓</span>
-          <span>
-            A full breakdown of your score across all{' '}
-            {result.domainScores.length} Security+ domains
-          </span>
-        </li>
-        <li className="flex items-start gap-2">
-          <span className="mt-0.5 text-accent">✓</span>
-          <span>
-            A personalized study plan calibrated to your current readiness score
-          </span>
-        </li>
-      </ul>
-
-      <form onSubmit={handleSubmit} className="mt-5 flex flex-col gap-3 sm:flex-row">
+      <form onSubmit={handleSubmit} className="mt-4 flex flex-col gap-3 sm:flex-row">
         <input
           type="email"
           required
@@ -91,14 +70,14 @@ export function EmailGate({ result, onUnlock }: EmailGateProps) {
           disabled={isPending}
           className="rounded-lg bg-accent px-6 py-3 text-sm font-medium text-[#060b06] transition-opacity hover:opacity-90 disabled:opacity-40"
         >
-          {isPending ? 'Sending...' : 'Send my plan →'}
+          {isPending ? 'Sending...' : 'Unlock →'}
         </button>
       </form>
 
       {error && <p className="mt-3 text-sm text-danger">{error}</p>}
 
       <p className="mt-3 text-xs text-muted/70">
-        No spam. One email with your plan — unsubscribe anytime if it&apos;s not useful.
+        No spam. Unsubscribe anytime.
       </p>
     </div>
   )


### PR DESCRIPTION
## Summary
- Strip the locked diagnostic results page to the absolute minimum: just the email gate + a tiny "Retake diagnostic" link. All score, pass-probability, weakest-domain and breakdown UI moves fully behind the email submit.
- Tighten the email gate itself — single one-line promise instead of three bullet points, "See your full results" headline, "Unlock →" button, single-line anti-spam footnote. Same captured data, ~65% less copy.
- Keep the unlocked state intact: the full DiagnosticResults card, domain breakdown, Cepeda citation and paid plan CTA still render after the user submits their email.

## Test plan
- [ ] Complete the diagnostic; on the results screen confirm only the email gate card and a small "Retake diagnostic" link render.
- [ ] Verify the email gate shows: "See your full results" headline, one-line promise sentence, email input, "Unlock →" button, and "No spam. Unsubscribe anytime." footnote — nothing else.
- [ ] Click "Retake diagnostic" and confirm it resets the flow back to intro.
- [ ] Submit a valid email; confirm the unlocked state renders the full results (readiness score, single stat card, domain breakdown, Cepeda citation, plan + paid CTA).
- [ ] Check mobile layout: email gate stacks cleanly and no residual empty blocks render above it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)