### PR TITLE
fix(diagnostic): log Resend failures + observability

### DIFF
--- a/features/diagnostic/actions.ts
+++ b/features/diagnostic/actions.ts
@@ -130,7 +130,7 @@ export async function submitDiagnosticLead(
       console.error('[diagnostic] Resend email failed:', sendError)
       void captureServerEvent({
         distinctId: email,
-        event: 'email_send_failed',
+        event: 'diagnostic_report_email_failed',
         properties: {
           source: 'diagnostic',
           error_name: sendError.name,
@@ -141,14 +141,17 @@ export async function submitDiagnosticLead(
       void captureServerEvent({
         distinctId: email,
         event: 'diagnostic_report_email_sent',
-        properties: { resend_id: data?.id },
+        properties: {
+          source: 'diagnostic',
+          resend_id: data?.id,
+        },
       })
     }
   } catch (err) {
     console.error('[diagnostic] Resend email failed:', err)
     void captureServerEvent({
       distinctId: email,
-      event: 'email_send_failed',
+      event: 'diagnostic_report_email_failed',
       properties: {
         source: 'diagnostic',
         error_name: err instanceof Error ? err.name : 'UnknownError',

--- a/features/diagnostic/actions.ts
+++ b/features/diagnostic/actions.ts
@@ -128,7 +128,7 @@ export async function submitDiagnosticLead(
 
     if (sendError) {
       console.error('[diagnostic] Resend email failed:', sendError)
-      await captureServerEvent({
+      void captureServerEvent({
         distinctId: email,
         event: 'email_send_failed',
         properties: {
@@ -138,7 +138,7 @@ export async function submitDiagnosticLead(
         },
       })
     } else {
-      await captureServerEvent({
+      void captureServerEvent({
         distinctId: email,
         event: 'diagnostic_report_email_sent',
         properties: { resend_id: data?.id },
@@ -146,11 +146,12 @@ export async function submitDiagnosticLead(
     }
   } catch (err) {
     console.error('[diagnostic] Resend email failed:', err)
-    await captureServerEvent({
+    void captureServerEvent({
       distinctId: email,
       event: 'email_send_failed',
       properties: {
         source: 'diagnostic',
+        error_name: err instanceof Error ? err.name : 'UnknownError',
         error_message: err instanceof Error ? err.message : String(err),
       },
     })

--- a/features/diagnostic/actions.ts
+++ b/features/diagnostic/actions.ts
@@ -119,14 +119,41 @@ export async function submitDiagnosticLead(
       weakestDomainName: weakestDomain?.name ?? 'Unknown',
     })
 
-    await resend().emails.send({
+    const { data, error: sendError } = await resend().emails.send({
       from: 'PassTheCert <reports@passthecert.com>',
       to: email,
       subject: `Your Security+ Diagnostic: ${overallScore}% — Here's Your Study Plan`,
       html,
     })
-  } catch {
-    // Email failure is non-blocking — lead is already captured
+
+    if (sendError) {
+      console.error('[diagnostic] Resend email failed:', sendError)
+      await captureServerEvent({
+        distinctId: email,
+        event: 'email_send_failed',
+        properties: {
+          source: 'diagnostic',
+          error_name: sendError.name,
+          error_message: sendError.message,
+        },
+      })
+    } else {
+      await captureServerEvent({
+        distinctId: email,
+        event: 'diagnostic_report_email_sent',
+        properties: { resend_id: data?.id },
+      })
+    }
+  } catch (err) {
+    console.error('[diagnostic] Resend email failed:', err)
+    await captureServerEvent({
+      distinctId: email,
+      event: 'email_send_failed',
+      properties: {
+        source: 'diagnostic',
+        error_message: err instanceof Error ? err.message : String(err),
+      },
+    })
   }
 
   return { success: true }


### PR DESCRIPTION
## What changed
- `features/diagnostic/actions.ts`: the Resend send in `submitDiagnosticLead()` now destructures both `data` and `error` from the Resend response, `console.error`s on both in-band errors and thrown errors, and emits PostHog `diagnostic_report_email_sent` on success and `diagnostic_report_email_failed` on failure (both carry `source: 'diagnostic'`).
- Telemetry calls inside the email `try/catch` are `void`-ed so PostHog latency does not extend the server action's response time.
- `submitDiagnosticLead` still returns `{ success: true }` once the lead is persisted, so email delivery failures do not fail the user-facing action.

## Why
The previous `try { ... } catch {}` swallowed every Resend error. Users were submitting the email gate, the lead was saved, the backend returned success, and the email never arrived — with zero signal anywhere. This fix gives us server logs + PostHog observability so the next failure is diagnosable immediately.

## Scope of "non-blocking"
"Non-blocking" here means **the lead write is not coupled to email delivery** — if Resend fails, the lead is still saved and the action still returns `{ success: true }`. The Resend send itself is awaited (so response time includes the Resend round-trip, typically 100–500ms); making the send truly fire-and-forget on Vercel serverless would require `waitUntil()` from `@vercel/functions`, which is out of scope for this fix.

## Things to verify manually
- [ ] `RESEND_API_KEY` is set in Vercel (Production + Preview + Development).
- [ ] `passthecert.com` is verified as a sending domain in the Resend dashboard — if not, sends from `reports@passthecert.com` will be rejected with a domain verification error, which will now show up in server logs and PostHog.
- [ ] After deploy, submit the diagnostic flow and check: Resend dashboard → Emails for the send; Vercel logs for any `[diagnostic] Resend email failed` lines; PostHog for `diagnostic_report_email_sent` vs `diagnostic_report_email_failed` events (filterable by `source = diagnostic`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)