### PR TITLE
feat(billing): 7-day free trial + tighten paywall enforcement

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -10,7 +10,13 @@ import {
 } from '@/features/progress'
 import { DomainMastery } from '@/features/progress/components/domain-mastery'
 import { StartPracticeCta } from '@/features/progress/components/start-practice-cta'
-import { isPro, UpgradeBanner, UpgradeSuccessBanner } from '@/features/billing'
+import {
+  isPro,
+  getTrialInfo,
+  TrialBanner,
+  UpgradeBanner,
+  UpgradeSuccessBanner,
+} from '@/features/billing'
 
 interface DashboardPageProps {
   searchParams: Promise<{ upgraded?: string }>
@@ -31,16 +37,25 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
     return <p className="text-muted">No exam configured.</p>
   }
 
-  const [readiness, domainMastery, streak, mastered, wrongAnswersCount, userIsPro, profile] =
-    await Promise.all([
-      getReadinessScore(user.id, exam.id),
-      getDomainMastery(user.id, exam.id),
-      getStudyStreak(user.id),
-      getQuestionsMastered(user.id),
-      getWrongAnswersCount(user.id),
-      isPro(user.id),
-      getProfile(user.id),
-    ])
+  const [
+    readiness,
+    domainMastery,
+    streak,
+    mastered,
+    wrongAnswersCount,
+    userIsPro,
+    profile,
+    trialInfo,
+  ] = await Promise.all([
+    getReadinessScore(user.id, exam.id),
+    getDomainMastery(user.id, exam.id),
+    getStudyStreak(user.id),
+    getQuestionsMastered(user.id),
+    getWrongAnswersCount(user.id),
+    isPro(user.id),
+    getProfile(user.id),
+    getTrialInfo(user.id),
+  ])
 
   const firstName =
     profile?.full_name?.split(' ')[0]?.trim() ||
@@ -58,6 +73,7 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
       />
 
       {upgraded === 'true' && !userIsPro && <UpgradeSuccessBanner />}
+      {trialInfo && <TrialBanner daysLeft={trialInfo.daysLeft} />}
       {userIsPro ? (
         <StartPracticeCta examSlug={exam.slug} hasMistakes={wrongAnswersCount > 0} />
       ) : (

--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -11,8 +11,7 @@ import {
 import { DomainMastery } from '@/features/progress/components/domain-mastery'
 import { StartPracticeCta } from '@/features/progress/components/start-practice-cta'
 import {
-  isPro,
-  getTrialInfo,
+  getBillingSummary,
   TrialBanner,
   UpgradeBanner,
   UpgradeSuccessBanner,
@@ -43,19 +42,19 @@ export default async function DashboardPage({ searchParams }: DashboardPageProps
     streak,
     mastered,
     wrongAnswersCount,
-    userIsPro,
+    billing,
     profile,
-    trialInfo,
   ] = await Promise.all([
     getReadinessScore(user.id, exam.id),
     getDomainMastery(user.id, exam.id),
     getStudyStreak(user.id),
     getQuestionsMastered(user.id),
     getWrongAnswersCount(user.id),
-    isPro(user.id),
+    getBillingSummary(user.id),
     getProfile(user.id),
-    getTrialInfo(user.id),
   ])
+
+  const { isPro: userIsPro, trialInfo } = billing
 
   const firstName =
     profile?.full_name?.split(' ')[0]?.trim() ||

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -1,4 +1,4 @@
-import { PRICE_AMOUNT } from '@/features/billing'
+import { PRICE_AMOUNT, TRIAL_GUARANTEE } from '@/features/billing'
 import Link from 'next/link'
 
 export default function LandingPage(): React.JSX.Element {
@@ -110,7 +110,7 @@ export default function LandingPage(): React.JSX.Element {
               Take the Free Diagnostic First
             </Link>
             <p className="mt-3 text-center text-xs text-muted">
-              Free for 7 days, then €14.99/mo — cancel anytime
+              {TRIAL_GUARANTEE}
             </p>
           </div>
         </div>

--- a/app/(marketing)/page.tsx
+++ b/app/(marketing)/page.tsx
@@ -110,7 +110,7 @@ export default function LandingPage(): React.JSX.Element {
               Take the Free Diagnostic First
             </Link>
             <p className="mt-3 text-center text-xs text-muted">
-              7-day money-back guarantee, no questions asked
+              Free for 7 days, then €14.99/mo — cancel anytime
             </p>
           </div>
         </div>

--- a/app/(marketing)/pricing/page.tsx
+++ b/app/(marketing)/pricing/page.tsx
@@ -1,5 +1,11 @@
 import { getUser } from '@/features/auth'
-import { checkIsPro, createCheckoutAndRedirect, PRICE_AMOUNT, PRICE_CTA } from '@/features/billing'
+import {
+  checkIsPro,
+  createCheckoutAndRedirect,
+  PRICE_AMOUNT,
+  PRICE_CTA,
+  TRIAL_GUARANTEE,
+} from '@/features/billing'
 import Link from 'next/link'
 
 const FEATURES = [
@@ -48,7 +54,7 @@ export default async function PricingPage(): Promise<React.JSX.Element> {
         <PricingCta isAuthenticated={!!user} isProUser={isProUser} />
 
         <p className="mt-3 text-center text-xs text-muted">
-          7-day money-back guarantee, no questions asked
+          {TRIAL_GUARANTEE}
         </p>
       </div>
     </main>

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -35,12 +35,13 @@ export async function POST(request: Request) {
       const userId = session.metadata?.supabase_user_id
 
       if (userId) {
+        // Only persist the customer link here. Subscription status (and trial
+        // end) are set by customer.subscription.created / .updated so we don't
+        // overwrite a 'trialing' status with 'active'.
         const { error } = await supabase
           .from('profiles')
           .update({
             stripe_customer_id: session.customer as string,
-            subscription_status: 'active',
-            subscription_tier: 'pro',
           })
           .eq('id', userId)
 
@@ -50,43 +51,58 @@ export async function POST(request: Request) {
 
         await captureServerEvent({
           distinctId: userId,
-          event: 'subscription_activated',
+          event: 'checkout_completed',
           properties: { stripe_session_id: session.id },
         })
       }
       break
     }
 
+    case 'customer.subscription.created':
     case 'customer.subscription.updated': {
       const subscription = event.data.object as Stripe.Subscription
       const customerId = subscription.customer as string
 
-      const isActive = subscription.status === 'active' || subscription.status === 'trialing'
+      const trialEndsAt =
+        subscription.trial_end != null
+          ? new Date(subscription.trial_end * 1000).toISOString()
+          : null
 
-      if (isActive) {
+      const updates: Record<string, unknown> = {
+        trial_ends_at: trialEndsAt,
+      }
+
+      switch (subscription.status) {
+        case 'trialing':
+        case 'active':
+          updates.subscription_status = subscription.status
+          updates.subscription_tier = 'pro'
+          break
+        case 'past_due':
+        case 'unpaid':
+        case 'canceled':
+        case 'incomplete_expired':
+          updates.subscription_status =
+            subscription.status === 'incomplete_expired'
+              ? 'canceled'
+              : subscription.status
+          // Keep tier='pro' so history is preserved; isPro() gates on status.
+          break
+        default:
+          // incomplete / paused / other transient states — do not overwrite
+          break
+      }
+
+      if (updates.subscription_status) {
         const { error } = await supabase
           .from('profiles')
-          .update({
-            subscription_status: 'active',
-            subscription_tier: 'pro',
-          })
-          .eq('stripe_customer_id', customerId)
-
-        if (error) {
-          return new Response('DB update failed', { status: 500 })
-        }
-      } else if (subscription.status === 'past_due') {
-        const { error } = await supabase
-          .from('profiles')
-          .update({ subscription_status: 'past_due' })
+          .update(updates)
           .eq('stripe_customer_id', customerId)
 
         if (error) {
           return new Response('DB update failed', { status: 500 })
         }
       }
-      // Ignore other statuses (incomplete, incomplete_expired) to avoid
-      // overwriting 'active' set by checkout.session.completed
       break
     }
 
@@ -99,6 +115,7 @@ export async function POST(request: Request) {
         .update({
           subscription_status: 'canceled',
           subscription_tier: 'free',
+          trial_ends_at: null,
         })
         .eq('stripe_customer_id', customerId)
 

--- a/app/api/webhooks/stripe/route.ts
+++ b/app/api/webhooks/stripe/route.ts
@@ -62,6 +62,10 @@ export async function POST(request: Request) {
     case 'customer.subscription.updated': {
       const subscription = event.data.object as Stripe.Subscription
       const customerId = subscription.customer as string
+      const metadataUserId =
+        typeof subscription.metadata?.supabase_user_id === 'string'
+          ? subscription.metadata.supabase_user_id
+          : null
 
       const trialEndsAt =
         subscription.trial_end != null
@@ -90,16 +94,32 @@ export async function POST(request: Request) {
           break
         default:
           // incomplete / paused / other transient states — do not overwrite
+          // status/tier, but still persist trial_ends_at so the banner is
+          // accurate if a trial is already in flight.
           break
       }
 
-      if (updates.subscription_status) {
-        const { error } = await supabase
-          .from('profiles')
-          .update(updates)
-          .eq('stripe_customer_id', customerId)
+      // Match by stripe_customer_id first. If that affects 0 rows (e.g.
+      // subscription.created arrived before checkout.session.completed had a
+      // chance to write stripe_customer_id), fall back to the supabase user id
+      // carried in subscription.metadata and backfill stripe_customer_id.
+      const { data: updatedByCustomer, error: customerErr } = await supabase
+        .from('profiles')
+        .update(updates)
+        .eq('stripe_customer_id', customerId)
+        .select('id')
 
-        if (error) {
+      if (customerErr) {
+        return new Response('DB update failed', { status: 500 })
+      }
+
+      if ((updatedByCustomer?.length ?? 0) === 0 && metadataUserId) {
+        const { error: fallbackErr } = await supabase
+          .from('profiles')
+          .update({ ...updates, stripe_customer_id: customerId })
+          .eq('id', metadataUserId)
+
+        if (fallbackErr) {
           return new Response('DB update failed', { status: 500 })
         }
       }

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -28,7 +28,7 @@ test.describe('Smoke Test — Critical User Flows', () => {
 
   test('unauthenticated user on pricing sees login CTA', async ({ page }) => {
     await page.goto('/pricing')
-    const cta = page.getByRole('link', { name: /subscribe/i })
+    const cta = page.getByRole('link', { name: /free trial/i })
     await expect(cta).toBeVisible({ timeout: 10_000 })
     await expect(cta).toHaveAttribute('href', /\/auth\/login/)
   })
@@ -70,7 +70,7 @@ test.describe('Smoke Test — Authenticated Flows', () => {
     await page.goto('/pricing')
     // Authenticated non-pro user sees submit button (form action) or "already subscribed"
     const checkoutBtn = page.getByRole('button', {
-      name: /subscribe/i,
+      name: /free trial/i,
     })
     const alreadySubscribed = page.getByText(/already have an active/i)
 
@@ -88,7 +88,7 @@ test.describe('Smoke Test — Authenticated Flows', () => {
 
     await page.goto('/pricing')
     const checkoutBtn = page.getByRole('button', {
-      name: /subscribe/i,
+      name: /free trial/i,
     })
 
     const isVisible = await checkoutBtn.isVisible()

--- a/features/billing/actions.ts
+++ b/features/billing/actions.ts
@@ -7,6 +7,7 @@ import { captureServerEvent } from '@/shared/lib/posthog-server'
 import { requireAuth } from '@/features/auth'
 import { redirect } from 'next/navigation'
 import { isPro } from './queries'
+import { TRIAL_DAYS } from './constants'
 
 export async function createCheckoutSession(): Promise<{ url: string }> {
   const user = await requireAuth()
@@ -46,12 +47,17 @@ export async function createCheckoutSession(): Promise<{ url: string }> {
   const session = await stripe().checkout.sessions.create({
     customer: customerId,
     mode: 'subscription',
+    payment_method_collection: 'always',
     line_items: [
       {
         price: env.STRIPE_PRO_PRICE_ID,
         quantity: 1,
       },
     ],
+    subscription_data: {
+      trial_period_days: TRIAL_DAYS,
+      metadata: { supabase_user_id: user.id },
+    },
     success_url: `${env.NEXT_PUBLIC_APP_URL}/dashboard?upgraded=true`,
     cancel_url: `${env.NEXT_PUBLIC_APP_URL}/dashboard`,
     metadata: { supabase_user_id: user.id },

--- a/features/billing/actions.ts
+++ b/features/billing/actions.ts
@@ -133,15 +133,19 @@ async function getActiveSubscriptionId(
 ): Promise<string> {
   const subscriptions = await stripe().subscriptions.list({
     customer: customerId,
-    status: 'active',
-    limit: 1,
+    status: 'all',
+    limit: 10,
   })
 
-  if (!subscriptions.data[0]) {
+  const cancelable = subscriptions.data.find(
+    (s) => s.status === 'active' || s.status === 'trialing'
+  )
+
+  if (!cancelable) {
     throw new Error('No active subscription found')
   }
 
-  return subscriptions.data[0].id
+  return cancelable.id
 }
 
 export async function createPortalAndRedirect(): Promise<never> {

--- a/features/billing/components/paywall.tsx
+++ b/features/billing/components/paywall.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react'
 import { createCheckoutAndRedirect } from '../actions'
-import { PRICE_CTA } from '../constants'
+import { PRICE_CTA, TRIAL_GUARANTEE } from '../constants'
 
 export function Paywall(): JSX.Element {
   return (
@@ -23,7 +23,7 @@ export function Paywall(): JSX.Element {
           Exclusive Content
         </h2>
         <p className="mx-auto mt-3 max-w-sm text-sm text-muted">
-          You need a subscription to access this content.
+          Start your 7-day free trial to access this content. Cancel anytime.
         </p>
         <form action={createCheckoutAndRedirect} className="mt-8">
           <button
@@ -33,9 +33,7 @@ export function Paywall(): JSX.Element {
             {PRICE_CTA}
           </button>
         </form>
-        <p className="mt-4 text-xs text-muted">
-          7-day money-back guarantee, no questions asked
-        </p>
+        <p className="mt-4 text-xs text-muted">{TRIAL_GUARANTEE}</p>
       </div>
     </div>
   )

--- a/features/billing/components/paywall.tsx
+++ b/features/billing/components/paywall.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react'
 import { createCheckoutAndRedirect } from '../actions'
-import { PRICE_CTA, TRIAL_GUARANTEE } from '../constants'
+import { PRICE_CTA, TRIAL_DAYS, TRIAL_GUARANTEE } from '../constants'
 
 export function Paywall(): JSX.Element {
   return (
@@ -23,7 +23,7 @@ export function Paywall(): JSX.Element {
           Exclusive Content
         </h2>
         <p className="mx-auto mt-3 max-w-sm text-sm text-muted">
-          Start your 7-day free trial to access this content. Cancel anytime.
+          Start your {TRIAL_DAYS}-day free trial to access this content. Cancel anytime.
         </p>
         <form action={createCheckoutAndRedirect} className="mt-8">
           <button

--- a/features/billing/components/trial-banner.tsx
+++ b/features/billing/components/trial-banner.tsx
@@ -1,0 +1,31 @@
+import type { JSX } from 'react'
+
+interface TrialBannerProps {
+  daysLeft: number
+}
+
+export function TrialBanner({ daysLeft }: TrialBannerProps): JSX.Element {
+  const safeDays = Math.max(0, Math.floor(daysLeft))
+
+  const label =
+    safeDays === 0
+      ? 'Free trial ends today.'
+      : safeDays === 1
+        ? 'Free trial — 1 day left.'
+        : `Free trial — ${safeDays} days left.`
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg border border-accent/30 bg-surface px-4 py-3 text-sm">
+      <p className="text-foreground">
+        <span className="font-medium text-accent">{label}</span>{' '}
+        <span className="text-muted">Cancel anytime from Settings.</span>
+      </p>
+      <a
+        href="/settings"
+        className="text-xs text-muted underline underline-offset-4 transition-colors hover:text-foreground"
+      >
+        Manage
+      </a>
+    </div>
+  )
+}

--- a/features/billing/components/trial-banner.tsx
+++ b/features/billing/components/trial-banner.tsx
@@ -1,11 +1,12 @@
 import type { JSX } from 'react'
+import Link from 'next/link'
 
 interface TrialBannerProps {
   daysLeft: number
 }
 
 export function TrialBanner({ daysLeft }: TrialBannerProps): JSX.Element {
-  const safeDays = Math.max(0, Math.floor(daysLeft))
+  const safeDays = Math.max(0, daysLeft)
 
   const label =
     safeDays === 0
@@ -20,12 +21,12 @@ export function TrialBanner({ daysLeft }: TrialBannerProps): JSX.Element {
         <span className="font-medium text-accent">{label}</span>{' '}
         <span className="text-muted">Cancel anytime from Settings.</span>
       </p>
-      <a
+      <Link
         href="/settings"
         className="text-xs text-muted underline underline-offset-4 transition-colors hover:text-foreground"
       >
         Manage
-      </a>
+      </Link>
     </div>
   )
 }

--- a/features/billing/components/upgrade-banner.tsx
+++ b/features/billing/components/upgrade-banner.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from 'react'
 import { createCheckoutAndRedirect } from '../actions'
-import { PRICE_LABEL } from '../constants'
+import { PRICE_LABEL, TRIAL_DAYS, TRIAL_GUARANTEE } from '../constants'
 
 export function UpgradeBanner(): JSX.Element {
   return (
@@ -28,10 +28,10 @@ export function UpgradeBanner(): JSX.Element {
           type="submit"
           className="rounded-lg bg-accent px-8 py-3 text-sm font-medium text-[#060b06] transition-opacity hover:opacity-90"
         >
-          Start Studying — {PRICE_LABEL}
+          Start {TRIAL_DAYS}-day free trial — then {PRICE_LABEL}
         </button>
       </form>
-      <p className="mt-3 text-xs text-muted">7-day money-back guarantee, no questions asked</p>
+      <p className="mt-3 text-xs text-muted">{TRIAL_GUARANTEE}</p>
     </div>
   )
 }

--- a/features/billing/constants.ts
+++ b/features/billing/constants.ts
@@ -1,4 +1,6 @@
 export const PRICE_AMOUNT = '€14.99'
 export const PRICE_INTERVAL = 'mo'
 export const PRICE_LABEL = `${PRICE_AMOUNT}/${PRICE_INTERVAL}`
-export const PRICE_CTA = `Subscribe — ${PRICE_LABEL}`
+export const TRIAL_DAYS = 7
+export const PRICE_CTA = `Start ${TRIAL_DAYS}-day free trial — then ${PRICE_LABEL}`
+export const TRIAL_GUARANTEE = `Free for ${TRIAL_DAYS} days, then ${PRICE_LABEL} — cancel anytime`

--- a/features/billing/index.ts
+++ b/features/billing/index.ts
@@ -7,8 +7,14 @@ export {
   cancelSubscriptionAndRedirect,
   checkIsPro,
 } from './actions'
-export { isPro, getSubscriptionStatus, getDailyQuestionCount, getTrialInfo } from './queries'
-export type { TrialInfo } from './queries'
+export {
+  isPro,
+  getSubscriptionStatus,
+  getDailyQuestionCount,
+  getTrialInfo,
+  getBillingSummary,
+} from './queries'
+export type { TrialInfo, BillingSummary } from './queries'
 export {
   PRICE_AMOUNT,
   PRICE_INTERVAL,

--- a/features/billing/index.ts
+++ b/features/billing/index.ts
@@ -7,9 +7,18 @@ export {
   cancelSubscriptionAndRedirect,
   checkIsPro,
 } from './actions'
-export { isPro, getSubscriptionStatus, getDailyQuestionCount } from './queries'
-export { PRICE_AMOUNT, PRICE_INTERVAL, PRICE_LABEL, PRICE_CTA } from './constants'
+export { isPro, getSubscriptionStatus, getDailyQuestionCount, getTrialInfo } from './queries'
+export type { TrialInfo } from './queries'
+export {
+  PRICE_AMOUNT,
+  PRICE_INTERVAL,
+  PRICE_LABEL,
+  PRICE_CTA,
+  TRIAL_DAYS,
+  TRIAL_GUARANTEE,
+} from './constants'
 export { UpgradeBanner } from './components/upgrade-banner'
 export { UpgradeSuccessBanner } from './components/upgrade-success-banner'
 export { Paywall } from './components/paywall'
+export { TrialBanner } from './components/trial-banner'
 export type { SubscriptionStatus } from './types'

--- a/features/billing/queries.ts
+++ b/features/billing/queries.ts
@@ -23,8 +23,43 @@ export async function isPro(userId: string): Promise<boolean> {
   }
 
   return (
-    data?.subscription_tier === 'pro' && data?.subscription_status === 'active'
+    data?.subscription_tier === 'pro' &&
+    (data?.subscription_status === 'active' ||
+      data?.subscription_status === 'trialing')
   )
+}
+
+export interface TrialInfo {
+  endsAt: string
+  daysLeft: number
+}
+
+export async function getTrialInfo(userId: string): Promise<TrialInfo | null> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('subscription_status, trial_ends_at')
+    .eq('id', userId)
+    .single()
+
+  if (error) {
+    throw new Error(`Failed to fetch trial info: ${error.message}`)
+  }
+
+  if (data?.subscription_status !== 'trialing' || !data?.trial_ends_at) {
+    return null
+  }
+
+  const endMs = new Date(data.trial_ends_at).getTime()
+  if (Number.isNaN(endMs)) return null
+
+  const daysLeft = Math.max(
+    0,
+    Math.ceil((endMs - Date.now()) / (1000 * 60 * 60 * 24)),
+  )
+
+  return { endsAt: data.trial_ends_at, daysLeft }
 }
 
 export async function getSubscriptionStatus(

--- a/features/billing/queries.ts
+++ b/features/billing/queries.ts
@@ -47,11 +47,47 @@ export async function getTrialInfo(userId: string): Promise<TrialInfo | null> {
     throw new Error(`Failed to fetch trial info: ${error.message}`)
   }
 
-  if (data?.subscription_status !== 'trialing' || !data?.trial_ends_at) {
-    return null
+  return deriveTrialInfo(data?.subscription_status, data?.trial_ends_at)
+}
+
+export interface BillingSummary {
+  isPro: boolean
+  trialInfo: TrialInfo | null
+}
+
+export async function getBillingSummary(
+  userId: string,
+): Promise<BillingSummary> {
+  const supabase = await createClient()
+
+  const { data, error } = await supabase
+    .from('profiles')
+    .select('subscription_tier, subscription_status, trial_ends_at')
+    .eq('id', userId)
+    .single()
+
+  if (error) {
+    throw new Error(`Failed to fetch billing summary: ${error.message}`)
   }
 
-  const endMs = new Date(data.trial_ends_at).getTime()
+  const isPro =
+    data?.subscription_tier === 'pro' &&
+    (data?.subscription_status === 'active' ||
+      data?.subscription_status === 'trialing')
+
+  return {
+    isPro,
+    trialInfo: deriveTrialInfo(data?.subscription_status, data?.trial_ends_at),
+  }
+}
+
+function deriveTrialInfo(
+  status: string | null | undefined,
+  trialEndsAt: string | null | undefined,
+): TrialInfo | null {
+  if (status !== 'trialing' || !trialEndsAt) return null
+
+  const endMs = new Date(trialEndsAt).getTime()
   if (Number.isNaN(endMs)) return null
 
   const daysLeft = Math.max(
@@ -59,7 +95,7 @@ export async function getTrialInfo(userId: string): Promise<TrialInfo | null> {
     Math.ceil((endMs - Date.now()) / (1000 * 60 * 60 * 24)),
   )
 
-  return { endsAt: data.trial_ends_at, daysLeft }
+  return { endsAt: trialEndsAt, daysLeft }
 }
 
 export async function getSubscriptionStatus(

--- a/features/diagnostic/components/diagnostic-results.tsx
+++ b/features/diagnostic/components/diagnostic-results.tsx
@@ -6,7 +6,7 @@ import type { DiagnosticResult } from '../types'
 // use next/headers. Server action modules ('use server') are safe as they
 // become RPC stubs on the client.
 import { createCheckoutAndRedirect } from '@/features/billing/actions'
-import { PRICE_LABEL } from '@/features/billing/constants'
+import { PRICE_LABEL, TRIAL_DAYS } from '@/features/billing/constants'
 
 interface DiagnosticResultsProps {
   result: DiagnosticResult
@@ -325,7 +325,7 @@ export function DiagnosticResults({
                       type="submit"
                       className="rounded-lg bg-accent px-8 py-3 text-sm font-medium text-[#060b06] transition-opacity hover:opacity-90"
                     >
-                      Lock it in with full-length exams — {PRICE_LABEL}
+                      Start {TRIAL_DAYS}-day free trial — then {PRICE_LABEL}
                     </button>
                   </form>
                 ) : (
@@ -333,11 +333,11 @@ export function DiagnosticResults({
                     href="/auth/login?next=/dashboard"
                     className="inline-block rounded-lg bg-accent px-8 py-3 text-sm font-medium text-[#060b06] transition-opacity hover:opacity-90"
                   >
-                    Lock it in with full-length exams — {PRICE_LABEL}
+                    Start {TRIAL_DAYS}-day free trial — then {PRICE_LABEL}
                   </a>
                 )}
                 <p className="mt-2 text-xs text-muted">
-                  7-day money-back guarantee · Cancel anytime
+                  Free for {TRIAL_DAYS} days, then {PRICE_LABEL} · Cancel anytime
                 </p>
               </div>
             </>
@@ -382,7 +382,7 @@ export function DiagnosticResults({
                       type="submit"
                       className="rounded-lg bg-accent px-8 py-3 text-sm font-medium text-[#060b06] transition-opacity hover:opacity-90"
                     >
-                      Start my plan — {PRICE_LABEL}
+                      Start {TRIAL_DAYS}-day free trial — then {PRICE_LABEL}
                     </button>
                   </form>
                 ) : (
@@ -390,11 +390,11 @@ export function DiagnosticResults({
                     href="/auth/login?next=/dashboard"
                     className="inline-block rounded-lg bg-accent px-8 py-3 text-sm font-medium text-[#060b06] transition-opacity hover:opacity-90"
                   >
-                    Start my plan — {PRICE_LABEL}
+                    Start {TRIAL_DAYS}-day free trial — then {PRICE_LABEL}
                   </a>
                 )}
                 <p className="mt-2 text-xs text-muted">
-                  7-day money-back guarantee · Cancel anytime
+                  Free for {TRIAL_DAYS} days, then {PRICE_LABEL} · Cancel anytime
                 </p>
               </div>
             </>

--- a/shared/types/database.ts
+++ b/shared/types/database.ts
@@ -4,7 +4,7 @@ export interface Profile {
   full_name: string | null
   avatar_url: string | null
   stripe_customer_id: string | null
-  subscription_status: 'trialing' | 'active' | 'canceled' | 'past_due'
+  subscription_status: 'trialing' | 'active' | 'canceled' | 'past_due' | 'unpaid' | 'inactive' | null
   subscription_tier: 'free' | 'pro'
   trial_ends_at: string | null
   created_at: string

--- a/shared/types/database.ts
+++ b/shared/types/database.ts
@@ -4,7 +4,7 @@ export interface Profile {
   full_name: string | null
   avatar_url: string | null
   stripe_customer_id: string | null
-  subscription_status: 'trialing' | 'active' | 'canceled' | 'past_due' | 'unpaid' | 'inactive' | null
+  subscription_status: 'trialing' | 'active' | 'canceled' | 'past_due' | 'unpaid' | null
   subscription_tier: 'free' | 'pro'
   trial_ends_at: string | null
   created_at: string


### PR DESCRIPTION
## What changed
- **Stripe Checkout**: `createCheckoutSession` now passes `payment_method_collection: 'always'` and `subscription_data: { trial_period_days: 7, metadata: { supabase_user_id } }` so the Checkout flow starts a 7-day trial with card collected upfront.
- **Entitlement**: `isPro()` now returns true for `tier='pro' && (status='active' || status='trialing')`, so trialing users have full Pro access.
- **Trial UI**: new `features/billing/components/trial-banner.tsx` + `getTrialInfo(userId)` query. Dashboard renders "Free trial — N days left. Cancel anytime from Settings." when user is trialing.
- **Copy everywhere updated**: paywall, upgrade banner, diagnostic results CTA, landing + pricing legal lines now read "Start 7-day free trial — then €14.99/mo" / "Free for 7 days, then €14.99/mo · Cancel anytime". Centralized in `features/billing/constants.ts` (`TRIAL_DAYS`, `TRIAL_GUARANTEE`, `PRICE_CTA`).
- **Stripe webhook hardened**:
  - `checkout.session.completed` only persists `stripe_customer_id` now (stops overwriting `trialing` with `active`).
  - `customer.subscription.created` / `.updated` merged: maps Stripe status → our column, writes `trial_ends_at` from `subscription.trial_end`, keeps `tier='pro'` on `trialing`/`active`, keeps tier but updates status on `past_due`/`unpaid`/`canceled`/`incomplete_expired`.
  - `customer.subscription.deleted` nulls `trial_ends_at`.
- **Types**: `Profile.subscription_status` widened to include `'unpaid' | 'inactive' | null`.

## Migration
`supabase/migrations/001_initial_schema.sql` already declares `trial_ends_at timestamptz` on profiles. No new migration.

## Free-tier behaviour (unchanged)
- Diagnostic is still free (outside this flow).
- Non-Pro users: 20 questions/day across Quick 10, Domain Focus, Review Mistakes. `full_exam` gated behind `isPro()` (now includes trialing).
- Mid-session users aren't cut off when they cross the daily limit — `submitAnswer` / `getNextQuestion` check session ownership, not entitlement.

## Things to verify manually in Stripe Dashboard
- [ ] Confirm the Price referenced by `STRIPE_PRO_PRICE_ID` env var is correct (€14.99/mo recurring).
- [ ] Test checkout with Stripe test card `4242 4242 4242 4242` and confirm the Checkout page shows the 7-day trial.
- [ ] Confirm the webhook endpoint is registered for `checkout.session.completed`, `customer.subscription.created`, `customer.subscription.updated`, `customer.subscription.deleted`, `invoice.payment_failed`.
- [ ] After completing Checkout, verify `profiles.subscription_status='trialing'`, `subscription_tier='pro'`, `trial_ends_at` is ~7 days out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)