### PR TITLE
fix(quiz): show server score on exam end screen

### DIFF
--- a/features/quiz/actions.ts
+++ b/features/quiz/actions.ts
@@ -215,7 +215,7 @@ export async function completeSession(sessionId: string) {
 
   const { data: session } = await supabase
     .from('quiz_sessions')
-    .select('total_questions, correct_count')
+    .select('total_questions, correct_count, is_completed')
     .eq('id', sessionId)
     .eq('user_id', user.id)
     .single()
@@ -226,25 +226,28 @@ export async function completeSession(sessionId: string) {
     (session.correct_count / session.total_questions) * 100
   )
 
-  await supabase
-    .from('quiz_sessions')
-    .update({
-      is_completed: true,
-      completed_at: new Date().toISOString(),
-      score_pct: scorePct,
-    })
-    .eq('id', sessionId)
+  // Idempotent: only write + emit the analytics event the first time.
+  if (!session.is_completed) {
+    await supabase
+      .from('quiz_sessions')
+      .update({
+        is_completed: true,
+        completed_at: new Date().toISOString(),
+        score_pct: scorePct,
+      })
+      .eq('id', sessionId)
 
-  await captureServerEvent({
-    distinctId: user.id,
-    event: 'study_session_completed',
-    properties: {
-      session_id: sessionId,
-      score_pct: scorePct,
-      correct_count: session.correct_count,
-      total_questions: session.total_questions,
-    },
-  })
+    await captureServerEvent({
+      distinctId: user.id,
+      event: 'study_session_completed',
+      properties: {
+        session_id: sessionId,
+        score_pct: scorePct,
+        correct_count: session.correct_count,
+        total_questions: session.total_questions,
+      },
+    })
+  }
 
   return { scorePct, correctCount: session.correct_count, totalQuestions: session.total_questions }
 }

--- a/features/quiz/actions.ts
+++ b/features/quiz/actions.ts
@@ -222,9 +222,8 @@ export async function completeSession(sessionId: string) {
 
   if (!session) throw new Error('Session not found')
 
-  const scorePct = Math.round(
-    (session.correct_count / session.total_questions) * 100
-  )
+  const correctCount = session.correct_count ?? 0
+  const scorePct = Math.round((correctCount / session.total_questions) * 100)
 
   // Idempotent: only write + emit the analytics event the first time.
   if (!session.is_completed) {
@@ -243,13 +242,13 @@ export async function completeSession(sessionId: string) {
       properties: {
         session_id: sessionId,
         score_pct: scorePct,
-        correct_count: session.correct_count,
+        correct_count: correctCount,
         total_questions: session.total_questions,
       },
     })
   }
 
-  return { scorePct, correctCount: session.correct_count, totalQuestions: session.total_questions }
+  return { scorePct, correctCount, totalQuestions: session.total_questions }
 }
 
 async function getNextQuestionForSession(

--- a/features/quiz/components/quiz-client.tsx
+++ b/features/quiz/components/quiz-client.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useTransition } from 'react'
-import { submitAnswer, getNextQuestion } from '../actions'
+import { submitAnswer, getNextQuestion, completeSession } from '../actions'
 import { QuestionCard } from '@/shared/components/ui/question-card'
 import { ExplanationPanel } from '@/shared/components/ui/explanation-panel'
 import type { Question } from '@/shared/types/database'
@@ -23,7 +23,6 @@ export function QuizClient({
   const [selectedKey, setSelectedKey] = useState<string | null>(null)
   const [result, setResult] = useState<AnswerResult | null>(null)
   const [questionIndex, setQuestionIndex] = useState(1)
-  const [correctCount, setCorrectCount] = useState(0)
   const [isSubmitting, startSubmit] = useTransition()
   const [isLoadingNext, startLoadNext] = useTransition()
   const [sessionComplete, setSessionComplete] = useState(false)
@@ -50,9 +49,6 @@ export function QuizClient({
         selectedKey
       )
       setResult(answerResult)
-      if (answerResult.isCorrect === true) {
-        setCorrectCount((c) => c + 1)
-      }
     })
   }
 
@@ -60,11 +56,15 @@ export function QuizClient({
     startLoadNext(async () => {
       const nextQuestion = await getNextQuestion(sessionId)
       if (!nextQuestion) {
-        setSessionComplete(true)
+        // Use server-authoritative score, not the locally-tracked counter.
+        // In full_exam mode `result.isCorrect` is always null, so the client
+        // counter is 0 — the DB is the only reliable source of truth.
+        const summary = await completeSession(sessionId)
         setFinalScore({
-          correct: correctCount,
-          total: totalQuestions,
+          correct: summary.correctCount,
+          total: summary.totalQuestions,
         })
+        setSessionComplete(true)
         return
       }
       setQuestion(nextQuestion)


### PR DESCRIPTION
## What changed
- `features/quiz/actions.ts` `completeSession` is now **idempotent** — only writes `is_completed=true` / `completed_at` / `score_pct` and emits the `study_session_completed` PostHog event when the session wasn't already completed. Safe for the client to call even if `getNextQuestion` auto-completed server-side.
- `features/quiz/components/quiz-client.tsx`:
  - Removed the locally-tracked `correctCount` state (always ended at 0 in exam mode because `isCorrect` is now `null` server-side post #73).
  - `handleNext` now calls `completeSession(sessionId)` when `getNextQuestion` returns `null` and uses the server-returned `{ correctCount, totalQuestions }` to populate `finalScore`.
- Applies to every mode (`random_10`, `domain_focus`, `review_mistakes`, `full_exam`) — the DB value is authoritative everywhere, not just in exam mode.

## Why
Follow-up to #73. After hiding per-question correctness in exam mode, the end-of-quiz screen was reading a client-tracked counter that never incremented. The real score is already in `quiz_sessions` (via the `increment_correct_count` RPC on each correct answer) and `completeSession` already returns it. This PR just connects the two.

## Stacks on #73
Merge #73 first; GitHub will auto-retarget this PR to `main` when the base branch lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)