### PR TITLE
Add statistical significance indicator to domain mastery scores

### DIFF
--- a/features/progress/components/domain-mastery.tsx
+++ b/features/progress/components/domain-mastery.tsx
@@ -1,5 +1,9 @@
 import Link from 'next/link'
 
+// Below this many unique answered questions, accuracy isn't statistically
+// meaningful. The UI flags the domain so users don't read the % as reliable.
+const MIN_SAMPLE = 10
+
 interface DomainData {
   domainId: string
   domainName: string
@@ -24,41 +28,60 @@ export function DomainMastery({ domains, examSlug }: DomainMasteryProps) {
         Accuracy on questions you&apos;ve practiced · Click to focus on a domain
       </p>
       <div className="mt-4 space-y-3">
-        {domains.map((domain) => (
-          <Link
-            key={domain.domainId}
-            href={`/quiz/${examSlug}?mode=domain_focus&domainId=${domain.domainId}`}
-            className="-mx-3 block rounded-lg px-3 py-3 transition-colors hover:bg-accent/5"
-          >
-            <div className="mb-1 flex items-center justify-between text-sm">
-              <span className="text-foreground">
-                {domain.code} {domain.domainName}
-              </span>
-              <div className="flex items-center gap-2">
-                <span className="font-medium text-foreground">
-                  {domain.correctPct}%
+        {domains.map((domain) => {
+          const insufficient = domain.totalAnswered < MIN_SAMPLE
+          return (
+            <Link
+              key={domain.domainId}
+              href={`/quiz/${examSlug}?mode=domain_focus&domainId=${domain.domainId}`}
+              className="-mx-3 block rounded-lg px-3 py-3 transition-colors hover:bg-accent/5"
+            >
+              <div className="mb-1 flex items-center justify-between text-sm">
+                <span className="text-foreground">
+                  {domain.code} {domain.domainName}
                 </span>
-                <span className="text-muted">&#8250;</span>
+                <div className="flex items-center gap-2">
+                  {insufficient && (
+                    <span
+                      title={`Answer at least ${MIN_SAMPLE} questions in this domain for a reliable score`}
+                      className="rounded-full border border-border bg-background px-2 py-0.5 text-[10px] font-medium uppercase tracking-wide text-muted"
+                    >
+                      Low sample
+                    </span>
+                  )}
+                  <span
+                    className={
+                      insufficient
+                        ? 'font-medium text-muted'
+                        : 'font-medium text-foreground'
+                    }
+                  >
+                    {domain.correctPct}%
+                  </span>
+                  <span className="text-muted">&#8250;</span>
+                </div>
               </div>
-            </div>
-            {/* Accuracy bar */}
-            <div className="h-2 rounded-full bg-background">
-              <div
-                className="h-full rounded-full bg-accent transition-all duration-500"
-                style={{ width: `${domain.correctPct}%` }}
-              />
-            </div>
-            {/* Coverage info */}
-            <div className="mt-1.5 flex items-center justify-between">
-              <span className="text-xs text-muted">
-                {domain.totalAnswered} / {domain.totalInDomain} questions seen
-              </span>
-              <span className="text-xs text-muted">
-                {domain.coveredPct}% covered · {domain.weightPct}% of exam
-              </span>
-            </div>
-          </Link>
-        ))}
+              {/* Accuracy bar */}
+              <div className="h-2 rounded-full bg-background">
+                <div
+                  className={`h-full rounded-full transition-all duration-500 ${
+                    insufficient ? 'bg-accent/30' : 'bg-accent'
+                  }`}
+                  style={{ width: `${domain.correctPct}%` }}
+                />
+              </div>
+              {/* Coverage info */}
+              <div className="mt-1.5 flex items-center justify-between">
+                <span className="text-xs text-muted">
+                  {domain.totalAnswered} / {domain.totalInDomain} questions seen
+                </span>
+                <span className="text-xs text-muted">
+                  {domain.coveredPct}% covered · {domain.weightPct}% of exam
+                </span>
+              </div>
+            </Link>
+          )
+        })}
         {domains.length === 0 && (
           <p className="text-sm text-muted">
             No data yet. Start practicing to see your progress.


### PR DESCRIPTION
## Summary
Enhanced the Domain Mastery component to flag domains with insufficient practice data, helping users understand when accuracy percentages may not be statistically reliable.

## Key Changes
- Added `MIN_SAMPLE` constant (10 questions) to define the threshold for statistically meaningful accuracy data
- Implemented "Low sample" badge that appears when a domain has fewer than the minimum required answered questions
- Updated accuracy percentage styling to use muted color when sample size is insufficient
- Modified accuracy progress bar to use reduced opacity (`bg-accent/30`) for low-sample domains
- Added tooltip to the "Low sample" badge explaining the requirement
- Refactored the map function to use a callback that calculates the `insufficient` flag for each domain

## Implementation Details
- The `insufficient` flag is computed per domain by comparing `domain.totalAnswered` against `MIN_SAMPLE`
- Visual feedback is consistent across the component: badge, text color, and progress bar all indicate low sample size
- The tooltip provides helpful context: "Answer at least 10 questions in this domain for a reliable score"
- All existing functionality and layout remain unchanged; this is purely an additive enhancement

https://claude.ai/code/session_018w6BJFt3CfbGm1CZ5nSvMt