### PR TITLE
fix(quiz): guard completeSession against null correct_count

### DIFF
--- a/features/quiz/actions.ts
+++ b/features/quiz/actions.ts
@@ -245,9 +245,8 @@ export async function completeSession(
 
   if (!session) throw new Error('Session not found')
 
-  const scorePct = Math.round(
-    (session.correct_count / session.total_questions) * 100
-  )
+  const correctCount = session.correct_count ?? 0
+  const scorePct = Math.round((correctCount / session.total_questions) * 100)
 
   await supabase
     .from('quiz_sessions')
@@ -264,12 +263,12 @@ export async function completeSession(
     properties: {
       session_id: sessionId,
       score_pct: scorePct,
-      correct_count: session.correct_count,
+      correct_count: correctCount,
       total_questions: session.total_questions,
     },
   })
 
-  return { scorePct, correctCount: session.correct_count, totalQuestions: session.total_questions }
+  return { scorePct, correctCount, totalQuestions: session.total_questions }
 }
 
 async function getNextQuestionForSession(


### PR DESCRIPTION
## What changed
Normalize `session.correct_count` to `0` once at the top of `completeSession`, then reuse the local `correctCount` in `scorePct`, the PostHog event payload, and the return value.

## Why
Defensive. The DB column defaults to `0`, so in practice this never fires — but `correct_count` is typed `number | null` in `shared/types/database.ts`, and `session.correct_count / session.total_questions` would produce `NaN` → `Math.round(NaN)` → `NaN` for the stored `score_pct` if it ever were null. One-line guard, zero behavior change in the normal path.

## Scope
- One function, one file, same logic
- No type signature changes
- No client callers affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_018w6BJFt3CfbGm1CZ5nSvMt)_